### PR TITLE
Fix whitespace erasure

### DIFF
--- a/fat/media/Scripts/rfid_write.sh
+++ b/fat/media/Scripts/rfid_write.sh
@@ -7,7 +7,7 @@ write_rom()
     get_title() {   
     trimPath=${1##*".rbf /media/fat/_Arcade/"}
     removeExtra=${trimPath%%.mra*}
-    echo $removeExtra
+    echo "$removeExtra"
     }
     gameTitle=$(get_title "$runningGame")
 


### PR DESCRIPTION
Fixed an unquoted variable which was causing white space to be removed in game titles with two spaces.