### PR TITLE
replaced filepath with a variable storing the filepath.

### DIFF
--- a/fat/media/Scripts/rfid_process.sh
+++ b/fat/media/Scripts/rfid_process.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 play() {
-        echo "load_core /media/fat/_Arcade/"$1".mra" > /dev/MiSTer_cmd
+        coreCommand="load_core /media/fat/_Arcade/"$1".mra"
+        echo "$coreCommand" > /dev/MiSTer_cmd
 }
 
 ha_cmd() {

--- a/fat/media/Scripts/rfid_write.sh
+++ b/fat/media/Scripts/rfid_write.sh
@@ -5,9 +5,7 @@ write_rom()
     cardNumber="$1"
     runningGame=\"$(ps aux | grep .mra)\"
     get_title() {   
-    trimPath=${1##*".rbf /media/fat/_Arcade/"}
-    removeExtra=${trimPath%%.mra*}
-    echo "$removeExtra"
+    echo "$1" | awk -F 'media/fat/_Arcade/' '{print $3}' | awk -F '\\.mra' '{print $1}'
     }
     gameTitle=$(get_title "$runningGame")
 


### PR DESCRIPTION
I'm not sure exactly the issue; but storing the `load_core` command as a variable and echoing the variable seems to fix double-spaces being truncated.