### PR TITLE
fixes for .neo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ _Games cannot be assigned/added when booted from an MGL file. You must do this p
 ## Known Issues
 
 NeoGeo games must use the `.neo` extension. You cannot use a darksoft roll-up without converting to `.neo`. This is a limitation from `.mgl` files and how they load.
+Also, the files should be named after the abbreviated rom name, for example `mslugx.neo` (see `neoGeo_games.sh`).
 
 ## Troubleshooting
 
@@ -180,6 +181,7 @@ NeoGeo games must use the `.neo` extension. You cannot use a darksoft roll-up wi
 - If your cards don't seem to be scanning in MiSTer, make sure that `serial_listen.sh` actually started. I have had issues with that not booting in the past. Re-imaging my SD card takes care of this if nothing else.
 - If games aren't being added to the right spot, or being injected in odd places in `game_list.conf` make sure you respected the format into `game_list.conf`. Read [MiSTer Setup](#MiSTer-Setup).
 - If your write card doesn't function. Make sure you added the card number to the Arduino code **and** re-uploaded after making that change.
+- If your NeoGeo games are not stored on `fat` (stored for example on `usb0`), try moving the .mgl file into `/media/fat/games/NeoGeo/`, and adapt the `game_list.conf` file to this new path.
 
 ## Quick Start
 

--- a/fat/media/Scripts/rfid_util/rfid_write.sh
+++ b/fat/media/Scripts/rfid_util/rfid_write.sh
@@ -19,7 +19,7 @@ write_rom() {
   #=========================================#
 
   findIt() {
-    foundGame=$(find "$fullPathToCoreGamesDir" -name "$1*" -type f -print)
+    foundGame=$(find "$fullPathToCoreGamesDir" -name "$1*" -type f -print | grep -v ".mgl")
   }
 
   prepFinalPaths() {
@@ -130,6 +130,7 @@ write_rom() {
         if [[ "$(echo "$game" | grep -w "${neoGeoEnglish[$i]}")" ]]; then #This code pulled from https://github.com/mrchrisster/MiSTer_SAM/blob/main/MiSTer_SAM_on.sh. Awesome idea!
           neoGeoName="$i"
           findIt "$neoGeoName"
+	  break
         fi
       done
     }
@@ -186,7 +187,7 @@ write_rom() {
       esac
 
     }
-    if [[ ${1} = NEOGEO ]]; then
+    if [[ ${coreName} = NEOGEO ]]; then
       neoGeoFileFixer "$coreName"
     fi
 


### PR DESCRIPTION
Hi!

Small fixes for the neogeo that make it work on my setup :) (with .neo files)

In case you wonder about the "grep -v", it's because I noticed that if I already had the mgl file, it was found as a game. I saw that when doing my tests, but it could happen if someone had already associated a game and tries to associate it to a new card.

Can you please check that it still works for your setup?

FYI, on my setup, I still have to move the .mgl file to the `fat` directory so that it manages to load the rom when I scan the card. That's why I added a tips into the readme about that.

Question:
I noticed in the two switch/case functions that we have a `*)` instead of `NEOGEO)` for the .srm and .neo.
Is it normal?
I didn't fix that because I had a doubt about what .srm files are (they should be snes save files, so I'm not sure about what's intended in that case).